### PR TITLE
Remove ISSM as a toolchain option

### DIFF
--- a/plugins/org.zephyrproject.ide.eclipse.core/src/org/zephyrproject/ide/eclipse/core/build/ZephyrToolChainConstants.java
+++ b/plugins/org.zephyrproject.ide.eclipse.core/src/org/zephyrproject/ide/eclipse/core/build/ZephyrToolChainConstants.java
@@ -57,21 +57,6 @@ public final class ZephyrToolChainConstants {
 
 	}
 
-	public static class IssmToolChain {
-
-		public static final String VARIANT = "issm"; //$NON-NLS-1$
-
-		public static final String DESCRIPTION =
-				"Intel System Studio for Microcontrollers";
-
-		public static final String DIRECTORY_DESCRIPTION =
-				String.join(ZephyrStrings.ONE_EMPTY_SPACE, "ISSM",
-						"Installation", ZephyrStrings.PATH);
-
-		public static final String ENV = "ISSM_INSTALLATION_PATH"; //$NON-NLS-1$
-
-	}
-
 	public static class CrossCompileToolChain {
 
 		public static final String VARIANT = "cross-compiler"; //$NON-NLS-1$
@@ -102,7 +87,6 @@ public final class ZephyrToolChainConstants {
 		ZephyrSdkToolChain.DESCRIPTION,
 		CrosstoolsToolChain.DESCRIPTION,
 		GnuArmEmbToolChain.DESCRIPTION,
-		IssmToolChain.DESCRIPTION,
 		CrossCompileToolChain.DESCRIPTION,
 		CustomToolChain.DESCRIPTION
 	};

--- a/plugins/org.zephyrproject.ide.eclipse.core/src/org/zephyrproject/ide/eclipse/core/internal/ZephyrHelpers.java
+++ b/plugins/org.zephyrproject.ide.eclipse.core/src/org/zephyrproject/ide/eclipse/core/internal/ZephyrHelpers.java
@@ -40,7 +40,6 @@ import org.zephyrproject.ide.eclipse.core.build.ZephyrToolChainConstants.CrossCo
 import org.zephyrproject.ide.eclipse.core.build.ZephyrToolChainConstants.CrosstoolsToolChain;
 import org.zephyrproject.ide.eclipse.core.build.ZephyrToolChainConstants.CustomToolChain;
 import org.zephyrproject.ide.eclipse.core.build.ZephyrToolChainConstants.GnuArmEmbToolChain;
-import org.zephyrproject.ide.eclipse.core.build.ZephyrToolChainConstants.IssmToolChain;
 import org.zephyrproject.ide.eclipse.core.build.ZephyrToolChainConstants.ZephyrSdkToolChain;
 import org.zephyrproject.ide.eclipse.core.internal.build.CMakeCache;
 import org.zephyrproject.ide.eclipse.core.launch.IZephyrLaunchHelper;
@@ -423,8 +422,6 @@ public final class ZephyrHelpers {
 			tcVarName = CrosstoolsToolChain.ENV;
 		} else if (variant.equals(GnuArmEmbToolChain.VARIANT)) {
 			tcVarName = GnuArmEmbToolChain.ENV;
-		} else if (variant.equals(IssmToolChain.VARIANT)) {
-			tcVarName = IssmToolChain.ENV;
 		} else if (variant.equals(CrossCompileToolChain.VARIANT)) {
 			tcVarName = CrossCompileToolChain.ENV;
 		} else {

--- a/plugins/org.zephyrproject.ide.eclipse.core/src/org/zephyrproject/ide/eclipse/core/preferences/ZephyrPreferenceConstants.java
+++ b/plugins/org.zephyrproject.ide.eclipse.core/src/org/zephyrproject/ide/eclipse/core/preferences/ZephyrPreferenceConstants.java
@@ -22,9 +22,6 @@ public class ZephyrPreferenceConstants {
 	public static final String P_XTOOLS_TOOLCHAIN_PATH =
 			"XTOOLS_TOOLCHAIN_PATH"; //$NON-NLS-1$
 
-	public static final String P_ISSM_INSTALLATION_PATH =
-			"ISSM_INSTALLATION_PATH"; //$NON-NLS-1$
-
 	public static final String P_CROSS_COMPILE_PREFIX = "CROSS_COMPILE_PREFIX"; //$NON-NLS-1$
 
 }

--- a/plugins/org.zephyrproject.ide.eclipse.core/src/org/zephyrproject/ide/eclipse/core/preferences/ZephyrPreferenceInitializer.java
+++ b/plugins/org.zephyrproject.ide.eclipse.core/src/org/zephyrproject/ide/eclipse/core/preferences/ZephyrPreferenceInitializer.java
@@ -35,8 +35,6 @@ public class ZephyrPreferenceInitializer extends AbstractPreferenceInitializer {
 				ZephyrStrings.EMPTY_STRING);
 		store.setDefault(ZephyrPreferenceConstants.P_XTOOLS_TOOLCHAIN_PATH,
 				ZephyrStrings.EMPTY_STRING);
-		store.setDefault(ZephyrPreferenceConstants.P_ISSM_INSTALLATION_PATH,
-				ZephyrStrings.EMPTY_STRING);
 		store.setDefault(ZephyrPreferenceConstants.P_CROSS_COMPILE_PREFIX,
 				ZephyrStrings.EMPTY_STRING);
 	}

--- a/plugins/org.zephyrproject.ide.eclipse.ui/src/org/zephyrproject/ide/eclipse/ui/preferences/ZephyrPreferenceToolchainPage.java
+++ b/plugins/org.zephyrproject.ide.eclipse.ui/src/org/zephyrproject/ide/eclipse/ui/preferences/ZephyrPreferenceToolchainPage.java
@@ -56,14 +56,6 @@ public class ZephyrPreferenceToolchainPage extends FieldEditorPreferencePage
 		xtoolsPath.setEmptyStringAllowed(true);
 		addField(xtoolsPath);
 
-		/* Intel ISSM Installation Path */
-		DirectoryFieldEditor issmPath = new DirectoryFieldEditor(
-				ZephyrPreferenceConstants.P_ISSM_INSTALLATION_PATH,
-				"Default &Intel ISSM Installation Path:",
-				getFieldEditorParent());
-		issmPath.setEmptyStringAllowed(true);
-		addField(issmPath);
-
 		/* Cross compile prefix */
 		StringFieldEditor crossCompilePrefix = new StringFieldEditor(
 				ZephyrPreferenceConstants.P_CROSS_COMPILE_PREFIX,

--- a/plugins/org.zephyrproject.ide.eclipse.ui/src/org/zephyrproject/ide/eclipse/ui/property/ZephyrApplicationToolchainPropertyPage.java
+++ b/plugins/org.zephyrproject.ide.eclipse.ui/src/org/zephyrproject/ide/eclipse/ui/property/ZephyrApplicationToolchainPropertyPage.java
@@ -31,7 +31,6 @@ import org.zephyrproject.ide.eclipse.core.build.ZephyrToolChainConstants.CrossCo
 import org.zephyrproject.ide.eclipse.core.build.ZephyrToolChainConstants.CrosstoolsToolChain;
 import org.zephyrproject.ide.eclipse.core.build.ZephyrToolChainConstants.CustomToolChain;
 import org.zephyrproject.ide.eclipse.core.build.ZephyrToolChainConstants.GnuArmEmbToolChain;
-import org.zephyrproject.ide.eclipse.core.build.ZephyrToolChainConstants.IssmToolChain;
 import org.zephyrproject.ide.eclipse.core.build.ZephyrToolChainConstants.ZephyrSdkToolChain;
 import org.zephyrproject.ide.eclipse.core.internal.ZephyrHelpers;
 
@@ -54,9 +53,6 @@ public class ZephyrApplicationToolchainPropertyPage extends PropertyPage
 
 	private Composite grpGnuArmEmb;
 	private Text gnuArmEmbDir;
-
-	private Composite grpISSM;
-	private Text issmDir;
 
 	private Composite grpCrossCompile;
 	private Text crossCompilePrefix;
@@ -150,8 +146,6 @@ public class ZephyrApplicationToolchainPropertyPage extends PropertyPage
 			tcDesc = CrosstoolsToolChain.DESCRIPTION;
 		} else if (storedTcVariant.equals(GnuArmEmbToolChain.VARIANT)) {
 			tcDesc = GnuArmEmbToolChain.DESCRIPTION;
-		} else if (storedTcVariant.equals(IssmToolChain.VARIANT)) {
-			tcDesc = IssmToolChain.DESCRIPTION;
 		} else if (storedTcVariant.equals(CrossCompileToolChain.VARIANT)) {
 			tcDesc = CrossCompileToolChain.DESCRIPTION;
 		} else {
@@ -177,9 +171,6 @@ public class ZephyrApplicationToolchainPropertyPage extends PropertyPage
 
 		grpGnuArmEmb = createOneControlGroup(tcParams);
 		createGroupGnuArmEmb(pStore);
-
-		grpISSM = createOneControlGroup(tcParams);
-		createGroupISSM(pStore);
 
 		grpCrossCompile = createOneControlGroup(tcParams);
 		createGroupCrossCompile(pStore);
@@ -349,22 +340,6 @@ public class ZephyrApplicationToolchainPropertyPage extends PropertyPage
 	};
 
 	/**
-	 * Create a group for Intel System Studio for Microcontrollers toolchain.
-	 */
-	private void createGroupISSM(ScopedPreferenceStore pStore) {
-		Composite grp = grpISSM;
-
-		createLabel(grp, IssmToolChain.DIRECTORY_DESCRIPTION + " (" //$NON-NLS-1$
-				+ IssmToolChain.ENV + "):"); //$NON-NLS-1$
-
-		issmDir = createDirField(grp);
-
-		issmDir.setText(pStore.getString(IssmToolChain.ENV));
-
-		createBrowseBtn(grp, issmDir);
-	};
-
-	/**
 	 * Create a group for specifying CROSS_COMPILE toolchain.
 	 */
 	private void createGroupCrossCompile(ScopedPreferenceStore pStore) {
@@ -416,10 +391,6 @@ public class ZephyrApplicationToolchainPropertyPage extends PropertyPage
 			tcVariant.setText(GnuArmEmbToolChain.VARIANT);
 			tcVariant.setEnabled(false);
 			tcParamsLayout.topControl = grpGnuArmEmb;
-		} else if (selection.equals(IssmToolChain.DESCRIPTION)) {
-			tcVariant.setText(IssmToolChain.VARIANT);
-			tcVariant.setEnabled(false);
-			tcParamsLayout.topControl = grpISSM;
 		} else if (selection.equals(CrossCompileToolChain.DESCRIPTION)) {
 			tcVariant.setText(CrossCompileToolChain.VARIANT);
 			tcVariant.setEnabled(false);
@@ -476,18 +447,6 @@ public class ZephyrApplicationToolchainPropertyPage extends PropertyPage
 				setErrorMessage(GnuArmEmbToolChain.DIRECTORY_DESCRIPTION
 						+ " is not valid");
 			}
-		} else if (selection.equals(IssmToolChain.DESCRIPTION)) {
-			String dir = issmDir.getText();
-
-			valid = ZephyrHelpers.checkValidDirectory(dir);
-
-			if (dir.isEmpty()) {
-				setErrorMessage(IssmToolChain.DIRECTORY_DESCRIPTION
-						+ " must be specified");
-			} else if (!valid) {
-				setErrorMessage(
-						IssmToolChain.DIRECTORY_DESCRIPTION + " is not valid");
-			}
 		} else if (selection.equals(CrossCompileToolChain.DESCRIPTION)) {
 			String prefix = crossCompilePrefix.getText();
 			if (!prefix.isEmpty()) {
@@ -539,9 +498,6 @@ public class ZephyrApplicationToolchainPropertyPage extends PropertyPage
 		} else if (variant.equals(GnuArmEmbToolChain.VARIANT)) {
 			String dir = gnuArmEmbDir.getText();
 			pStore.putValue(GnuArmEmbToolChain.ENV, dir);
-		} else if (variant.equals(IssmToolChain.VARIANT)) {
-			String dir = issmDir.getText();
-			pStore.putValue(IssmToolChain.ENV, dir);
 		} else if (variant.equals(CrossCompileToolChain.VARIANT)) {
 			String prefix = crossCompilePrefix.getText();
 			pStore.putValue(CrossCompileToolChain.ENV, prefix);

--- a/plugins/org.zephyrproject.ide.eclipse.ui/src/org/zephyrproject/ide/eclipse/ui/wizards/internal/ZephyrApplicationToolchainWizardPage.java
+++ b/plugins/org.zephyrproject.ide.eclipse.ui/src/org/zephyrproject/ide/eclipse/ui/wizards/internal/ZephyrApplicationToolchainWizardPage.java
@@ -37,7 +37,6 @@ import org.zephyrproject.ide.eclipse.core.build.ZephyrToolChainConstants.CrossCo
 import org.zephyrproject.ide.eclipse.core.build.ZephyrToolChainConstants.CrosstoolsToolChain;
 import org.zephyrproject.ide.eclipse.core.build.ZephyrToolChainConstants.CustomToolChain;
 import org.zephyrproject.ide.eclipse.core.build.ZephyrToolChainConstants.GnuArmEmbToolChain;
-import org.zephyrproject.ide.eclipse.core.build.ZephyrToolChainConstants.IssmToolChain;
 import org.zephyrproject.ide.eclipse.core.build.ZephyrToolChainConstants.ZephyrSdkToolChain;
 import org.zephyrproject.ide.eclipse.core.internal.ZephyrHelpers;
 import org.zephyrproject.ide.eclipse.core.preferences.ZephyrPreferenceConstants;
@@ -81,9 +80,6 @@ public class ZephyrApplicationToolchainWizardPage extends WizardPage {
 	private Composite grpGnuArmEmb;
 	private Text gnuArmEmbDir;
 
-	private Composite grpISSM;
-	private Text issmDir;
-
 	private Composite grpCrossCompile;
 	private Text crossCompilePrefix;
 
@@ -117,10 +113,6 @@ public class ZephyrApplicationToolchainWizardPage extends WizardPage {
 			tcVariant.setText(GnuArmEmbToolChain.VARIANT);
 			tcVariant.setEnabled(false);
 			tcParamsLayout.topControl = grpGnuArmEmb;
-		} else if (selection.equals(IssmToolChain.DESCRIPTION)) {
-			tcVariant.setText(IssmToolChain.VARIANT);
-			tcVariant.setEnabled(false);
-			tcParamsLayout.topControl = grpISSM;
 		} else if (selection.equals(CrossCompileToolChain.DESCRIPTION)) {
 			tcVariant.setText(CrossCompileToolChain.VARIANT);
 			tcVariant.setEnabled(false);
@@ -296,23 +288,6 @@ public class ZephyrApplicationToolchainWizardPage extends WizardPage {
 	};
 
 	/**
-	 * Create a group for Intel System Studio for Microcontrollers toolchain.
-	 */
-	private void createGroupISSM() {
-		Composite grp = grpISSM;
-
-		createLabel(grp, IssmToolChain.DIRECTORY_DESCRIPTION + " (" //$NON-NLS-1$
-				+ IssmToolChain.ENV + "):"); //$NON-NLS-1$
-
-		issmDir = createDirField(grp);
-
-		issmDir.setText(zTopPref
-				.getString(ZephyrPreferenceConstants.P_ISSM_INSTALLATION_PATH));
-
-		createBrowseBtn(grp, issmDir);
-	};
-
-	/**
 	 * Create a group for specifying CROSS_COMPILE toolchain.
 	 */
 	private void createGroupCrossCompile() {
@@ -409,9 +384,6 @@ public class ZephyrApplicationToolchainWizardPage extends WizardPage {
 		grpGnuArmEmb = createOneControlGroup(tcParams);
 		createGroupGnuArmEmb();
 
-		grpISSM = createOneControlGroup(tcParams);
-		createGroupISSM();
-
 		grpCrossCompile = createOneControlGroup(tcParams);
 		createGroupCrossCompile();
 
@@ -471,20 +443,6 @@ public class ZephyrApplicationToolchainWizardPage extends WizardPage {
 			} else if (!valid) {
 				setErrorMessage(GnuArmEmbToolChain.DIRECTORY_DESCRIPTION
 						+ " is not valid");
-				setMessage(null);
-			}
-		} else if (selection.equals(IssmToolChain.DESCRIPTION)) {
-			String dir = issmDir.getText();
-
-			valid = ZephyrHelpers.checkValidDirectory(dir);
-
-			if (dir.isEmpty()) {
-				setErrorMessage(null);
-				setMessage(IssmToolChain.DIRECTORY_DESCRIPTION
-						+ " must be specified");
-			} else if (!valid) {
-				setErrorMessage(
-						IssmToolChain.DIRECTORY_DESCRIPTION + " is not valid");
 				setMessage(null);
 			}
 		} else if (selection.equals(CrossCompileToolChain.DESCRIPTION)) {
@@ -548,9 +506,6 @@ public class ZephyrApplicationToolchainWizardPage extends WizardPage {
 		} else if (variant.equals(GnuArmEmbToolChain.VARIANT)) {
 			String dir = gnuArmEmbDir.getText();
 			pStore.putValue(GnuArmEmbToolChain.ENV, dir);
-		} else if (variant.equals(IssmToolChain.VARIANT)) {
-			String dir = issmDir.getText();
-			pStore.putValue(IssmToolChain.ENV, dir);
 		} else if (variant.equals(CrossCompileToolChain.VARIANT)) {
 			String prefix = crossCompilePrefix.getText();
 			pStore.putValue(CrossCompileToolChain.ENV, prefix);


### PR DESCRIPTION
ISSM toolchain support has been removed from Zephyr master so
the ISSM toolchain options are removed from the plugin.

Fixes #1

Signed-off-by: Daniel Leung <daniel.leung@intel.com>