### PR TITLE
Saving toolchain path and west arguments

### DIFF
--- a/plugins/org.zephyrproject.ide.eclipse.ui/src/org/zephyrproject/ide/eclipse/ui/launch/tabs/HardwareDebugLaunchMainTab.java
+++ b/plugins/org.zephyrproject.ide.eclipse.ui/src/org/zephyrproject/ide/eclipse/ui/launch/tabs/HardwareDebugLaunchMainTab.java
@@ -168,6 +168,9 @@ public class HardwareDebugLaunchMainTab extends CMainTab2 {
 				btnDbgSrvBuildSys.setSelection(false);
 				btnDbgSrvWest.setSelection(true);
 				westDbgSrvArgsText.setEnabled(true);
+				westDbgSrvArgsText.setText(configuration.getAttribute(
+						ZephyrLaunchConstants.ATTR_DBGSERVER_CMD_WEST_ARGS,
+						EMPTY_STRING));
 			} else {
 				/* Also "DBGSERVER_CMD_SEL_NONE" */
 				btnDbgSrvNone.setSelection(true);
@@ -200,6 +203,9 @@ public class HardwareDebugLaunchMainTab extends CMainTab2 {
 				btnFlashTargetBuildSys.setSelection(false);
 				btnFlashTargetWest.setSelection(true);
 				westFlashArgsText.setEnabled(true);
+				westFlashArgsText.setText(configuration.getAttribute(
+						ZephyrLaunchConstants.ATTR_FLASH_CMD_WEST_ARGS,
+						EMPTY_STRING));
 			} else {
 				/* Also "FLASH_CMD_SEL_NONE" */
 				btnFlashTargetNone.setSelection(true);

--- a/plugins/org.zephyrproject.ide.eclipse.ui/src/org/zephyrproject/ide/eclipse/ui/wizards/internal/ZephyrApplicationToolchainWizardPage.java
+++ b/plugins/org.zephyrproject.ide.eclipse.ui/src/org/zephyrproject/ide/eclipse/ui/wizards/internal/ZephyrApplicationToolchainWizardPage.java
@@ -247,8 +247,8 @@ public class ZephyrApplicationToolchainWizardPage extends WizardPage {
 
 		zephyrSdkInstallDir = createDirField(grp);
 
-		zephyrSdkInstallDir.setText(zTopPref
-				.getString(ZephyrPreferenceConstants.P_ZEPHYR_SDK_INSTALL_DIR));
+		zephyrSdkInstallDir.setText(getPathFromDefault(
+				ZephyrPreferenceConstants.P_ZEPHYR_SDK_INSTALL_DIR));
 
 		createBrowseBtn(grp, zephyrSdkInstallDir);
 	};
@@ -264,8 +264,8 @@ public class ZephyrApplicationToolchainWizardPage extends WizardPage {
 
 		xtoolsDir = createDirField(grp);
 
-		xtoolsDir.setText(zTopPref
-				.getString(ZephyrPreferenceConstants.P_XTOOLS_TOOLCHAIN_PATH));
+		xtoolsDir.setText(getPathFromDefault(
+				ZephyrPreferenceConstants.P_XTOOLS_TOOLCHAIN_PATH));
 
 		createBrowseBtn(grp, xtoolsDir);
 	};
@@ -281,7 +281,7 @@ public class ZephyrApplicationToolchainWizardPage extends WizardPage {
 
 		gnuArmEmbDir = createDirField(grp);
 
-		gnuArmEmbDir.setText(zTopPref.getString(
+		gnuArmEmbDir.setText(getPathFromDefault(
 				ZephyrPreferenceConstants.P_GNUARMEMB_TOOLCHAIN_PATH));
 
 		createBrowseBtn(grp, gnuArmEmbDir);
@@ -298,8 +298,8 @@ public class ZephyrApplicationToolchainWizardPage extends WizardPage {
 
 		crossCompilePrefix = createTextField(grp);
 
-		crossCompilePrefix.setText(zTopPref
-				.getString(ZephyrPreferenceConstants.P_CROSS_COMPILE_PREFIX));
+		crossCompilePrefix.setText(getPathFromDefault(
+				ZephyrPreferenceConstants.P_CROSS_COMPILE_PREFIX));
 
 		createBrowseBtn(grp, crossCompilePrefix);
 	};
@@ -317,6 +317,17 @@ public class ZephyrApplicationToolchainWizardPage extends WizardPage {
 
 		createBrowseBtn(grp, customRoot);
 	};
+
+	private String getPathFromDefault(String toolchain) {
+		String defaultPath = zTopPref.getString(toolchain);
+		String path = getDialogSettings().get(toolchain);
+		if (!defaultPath.isEmpty())
+			return defaultPath;
+		else if (path != null)
+			return path;
+		else
+			return ZephyrStrings.EMPTY_STRING;
+	}
 
 	@Override
 	public void createControl(Composite parent) {
@@ -500,18 +511,27 @@ public class ZephyrApplicationToolchainWizardPage extends WizardPage {
 		if (variant.equals(ZephyrSdkToolChain.VARIANT)) {
 			String dir = zephyrSdkInstallDir.getText();
 			pStore.putValue(ZephyrSdkToolChain.ENV, dir);
+			getDialogSettings().put(
+					ZephyrPreferenceConstants.P_ZEPHYR_SDK_INSTALL_DIR, dir);
 		} else if (variant.equals(CrosstoolsToolChain.VARIANT)) {
 			String dir = xtoolsDir.getText();
 			pStore.putValue(CrosstoolsToolChain.ENV, dir);
+			getDialogSettings().put(
+					ZephyrPreferenceConstants.P_XTOOLS_TOOLCHAIN_PATH, dir);
 		} else if (variant.equals(GnuArmEmbToolChain.VARIANT)) {
 			String dir = gnuArmEmbDir.getText();
 			pStore.putValue(GnuArmEmbToolChain.ENV, dir);
+			getDialogSettings().put(
+					ZephyrPreferenceConstants.P_GNUARMEMB_TOOLCHAIN_PATH, dir);
 		} else if (variant.equals(CrossCompileToolChain.VARIANT)) {
 			String prefix = crossCompilePrefix.getText();
 			pStore.putValue(CrossCompileToolChain.ENV, prefix);
+			getDialogSettings().put(
+					ZephyrPreferenceConstants.P_CROSS_COMPILE_PREFIX, prefix);
 		} else {
 			String tcRoot = customRoot.getText();
 			pStore.putValue(CustomToolChain.ENV, tcRoot);
+			getDialogSettings().put(CustomToolChain.ENV, tcRoot);
 		}
 
 		pStore.save();


### PR DESCRIPTION
- Saving and showing the toolchain paths previously used for other zephyr projects when creating a new project
- Showing west arguments on hardware debug configuration previously used