### PR TITLE
Plugin: debugConf: parsing error on west arguments

### DIFF
--- a/plugins/org.zephyrproject.ide.eclipse.core.java11/src/org/zephyrproject/ide/eclipse/core/internal/launch/java11/ZephyrLaunchHelpers.java
+++ b/plugins/org.zephyrproject.ide.eclipse.core.java11/src/org/zephyrproject/ide/eclipse/core/internal/launch/java11/ZephyrLaunchHelpers.java
@@ -8,6 +8,7 @@ package org.zephyrproject.ide.eclipse.core.internal.launch.java11;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
@@ -75,7 +76,7 @@ public final class ZephyrLaunchHelpers implements IZephyrLaunchHelper {
 		cmds.add(westPath);
 		cmds.add(action);
 		if (args != null) {
-			cmds.add(args);
+			cmds.addAll(ZephyrHelpers.getArguments(args));
 		}
 
 		String[] command = cmds.toArray(new String[0]);

--- a/plugins/org.zephyrproject.ide.eclipse.core.java11/src/org/zephyrproject/ide/eclipse/core/internal/launch/java11/ZephyrLaunchHelpers.java
+++ b/plugins/org.zephyrproject.ide.eclipse.core.java11/src/org/zephyrproject/ide/eclipse/core/internal/launch/java11/ZephyrLaunchHelpers.java
@@ -76,7 +76,7 @@ public final class ZephyrLaunchHelpers implements IZephyrLaunchHelper {
 		cmds.add(westPath);
 		cmds.add(action);
 		if (args != null) {
-			cmds.addAll(ZephyrHelpers.getArguments(args));
+			cmds.addAll(ZephyrHelpers.parseWestArguments(args));
 		}
 
 		String[] command = cmds.toArray(new String[0]);

--- a/plugins/org.zephyrproject.ide.eclipse.core/src/org/zephyrproject/ide/eclipse/core/internal/ZephyrHelpers.java
+++ b/plugins/org.zephyrproject.ide.eclipse.core/src/org/zephyrproject/ide/eclipse/core/internal/ZephyrHelpers.java
@@ -10,6 +10,7 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -493,5 +494,21 @@ public final class ZephyrHelpers {
 	 */
 	public static String getProjectPreference(IProject project, String key) {
 		return getProjectPreference(getProjectPreferenceStore(project), key);
+	}
+
+	/**
+	 * Parses the west arguments into a list removing unnecessary spaces
+	 *
+	 * @param args String of arguments to run west
+	 * @return List of arguments or null if there is no argument
+	 */
+	public static List<String> getArguments(String args) {
+		args = args.trim().replaceAll("\\s+", " ");
+		if (args != null && !args.isEmpty()) {
+			return Arrays.asList(args.split(" "));
+		}
+		else {
+			return null;
+		}
 	}
 }

--- a/plugins/org.zephyrproject.ide.eclipse.core/src/org/zephyrproject/ide/eclipse/core/internal/ZephyrHelpers.java
+++ b/plugins/org.zephyrproject.ide.eclipse.core/src/org/zephyrproject/ide/eclipse/core/internal/ZephyrHelpers.java
@@ -502,7 +502,7 @@ public final class ZephyrHelpers {
 	 * @param args String of arguments to run west
 	 * @return List of arguments or null if there is no argument
 	 */
-	public static List<String> getArguments(String args) {
+	public static List<String> parseWestArguments(String args) {
 		args = args.trim().replaceAll("\\s+", " ");
 		if (args != null && !args.isEmpty()) {
 			return Arrays.asList(args.split(" "));


### PR DESCRIPTION
Arguments taken from "Debug server" and "Command to run" when invoking
west in Debug configuration are not parsed correctly.
Creation of a function to remove trailling spaces.
Fixes #12

Signed-off-by: Marta Navarro <marta.navarro@intel.com>