### PR TITLE
Plugin: projProps: saving props on Apply and Close

### DIFF
--- a/plugins/org.zephyrproject.ide.eclipse.ui/src/org/zephyrproject/ide/eclipse/ui/property/ZephyrApplicationToolchainPropertyPage.java
+++ b/plugins/org.zephyrproject.ide.eclipse.ui/src/org/zephyrproject/ide/eclipse/ui/property/ZephyrApplicationToolchainPropertyPage.java
@@ -513,4 +513,10 @@ public class ZephyrApplicationToolchainPropertyPage extends PropertyPage
 		}
 	}
 
+	@Override
+	public boolean performOk() {
+		performApply();
+		return true;
+	}
+
 }

--- a/plugins/org.zephyrproject.ide.eclipse.ui/src/org/zephyrproject/ide/eclipse/ui/property/ZephyrApplicationTopPropertyPage.java
+++ b/plugins/org.zephyrproject.ide.eclipse.ui/src/org/zephyrproject/ide/eclipse/ui/property/ZephyrApplicationTopPropertyPage.java
@@ -81,7 +81,6 @@ public class ZephyrApplicationTopPropertyPage extends PropertyPage
 
 	@Override
 	protected void performApply() {
-		super.performApply();
 
 		IProject project = getElement().getAdapter(IProject.class);
 		ScopedPreferenceStore pStore =
@@ -95,6 +94,12 @@ public class ZephyrApplicationTopPropertyPage extends PropertyPage
 		} catch (IOException e) {
 			e.printStackTrace();
 		}
+	}
+
+	@Override
+	public boolean performOk() {
+		performApply();
+		return true;
 	}
 
 }


### PR DESCRIPTION
Zephyr project properties weren't saved from "Apply and Close" button on
Properties Dialog Box. Adding the functionality.
Fixes #20

Signed-off-by: Marta Navarro <marta.navarro@intel.com>