### PR TITLE
Add openipc runner for debugging

### DIFF
--- a/plugins/org.zephyrproject.ide.eclipse.core/plugin.xml
+++ b/plugins/org.zephyrproject.ide.eclipse.core/plugin.xml
@@ -194,6 +194,11 @@
             id="org.zephyrproject.ide.eclipse.core.debug.jtagdevice.nios2Device"
             name="Nios II GDB Server">
       </device>
+      <device
+            class="org.zephyrproject.ide.eclipse.core.debug.jtagdevice.OpenIPCDevice"
+            id="org.zephyrproject.ide.eclipse.core.debug.jtagdevice.openIPCDevice"
+            name="OpenIPC">
+      </device>
             <device
             class="org.eclipse.cdt.debug.gdbjtag.core.jtagdevice.DefaultGDBJtagConnectionImpl"
             default_connection="/dev/ttyACM0"

--- a/plugins/org.zephyrproject.ide.eclipse.core/src/org/zephyrproject/ide/eclipse/core/debug/jtagdevice/OpenIPCDevice.java
+++ b/plugins/org.zephyrproject.ide.eclipse.core/src/org/zephyrproject/ide/eclipse/core/debug/jtagdevice/OpenIPCDevice.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2008, 2012 QNX Software Systems and others.
+ * Copyright (c) 2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+/*
+ * Originally from org.eclipse.cdt.debug.gdbjtag.core.jtagdevice.GenericDevice
+ */
+
+package org.zephyrproject.ide.eclipse.core.debug.jtagdevice;
+
+import java.util.Collection;
+
+import org.eclipse.cdt.debug.gdbjtag.core.jtagdevice.DefaultGDBJtagDeviceImpl;
+
+public class OpenIPCDevice extends DefaultGDBJtagDeviceImpl {
+
+	@Override
+	public String getDefaultPortNumber() {
+		return "8086"; //$NON-NLS-1$
+	}
+
+	@Override
+	public void doDelay(int delay, Collection<String> commands) {
+		addCmd(commands, "monitor sleep " + String.valueOf(delay * 1000)); //$NON-NLS-1$
+	}
+
+	@Override
+	public void doResetAndHalt(Collection<String> commands) {
+		addCmd(commands, "monitor reset halt"); //$NON-NLS-1$
+	}
+
+}

--- a/plugins/org.zephyrproject.ide.eclipse.ui/src/org/zephyrproject/ide/eclipse/ui/internal/launch/tabs/CommonDebugLaunchDebuggerTab.java
+++ b/plugins/org.zephyrproject.ide.eclipse.ui/src/org/zephyrproject/ide/eclipse/ui/internal/launch/tabs/CommonDebugLaunchDebuggerTab.java
@@ -55,6 +55,9 @@ public abstract class CommonDebugLaunchDebuggerTab
 		new JTagDeviceDesc("openocd", //$NON-NLS-1$
 				"org.eclipse.cdt.debug.gdbjtag.core.jtagdevice.OpenOCDSocket", //$NON-NLS-1$
 				JTagDeviceDesc.IP_ADDR_LOCALHOST, 3333),
+		new JTagDeviceDesc("openipc", //$NON-NLS-1$
+				"org.zephyrproject.ide.eclipse.core.debug.jtagdevice.openIPCDevice", //$NON-NLS-1$
+				JTagDeviceDesc.IP_ADDR_LOCALHOST, 8086),
 	};
 
 	@Override


### PR DESCRIPTION
Adding openipc runner on debug configuration to launch openipc through
west debugserver

Signed-off-by: Marta Navarro <marta.navarro@intel.com>