### PR TITLE
Fix West related issues

### DIFF
--- a/plugins/org.zephyrproject.ide.eclipse.core.java11/src/org/zephyrproject/ide/eclipse/core/internal/launch/java11/ZephyrLaunchHelpers.java
+++ b/plugins/org.zephyrproject.ide.eclipse.core.java11/src/org/zephyrproject/ide/eclipse/core/internal/launch/java11/ZephyrLaunchHelpers.java
@@ -106,7 +106,16 @@ public final class ZephyrLaunchHelpers implements IZephyrLaunchHelper {
 		}
 
 		ArrayList<String> cmds = new ArrayList<String>();
-		cmds.add(westPath);
+
+		if (westPath.indexOf(';') == -1) {
+			cmds.add(westPath);
+		} else {
+			String[] westPathBits = westPath.split(";");
+			for (String s : westPathBits) {
+				cmds.add(s);
+			}
+		}
+
 		cmds.add(action);
 		if (args != null) {
 			cmds.addAll(ZephyrHelpers.parseWestArguments(args));

--- a/plugins/org.zephyrproject.ide.eclipse.core.java11/src/org/zephyrproject/ide/eclipse/core/internal/launch/java11/ZephyrLaunchHelpers.java
+++ b/plugins/org.zephyrproject.ide.eclipse.core.java11/src/org/zephyrproject/ide/eclipse/core/internal/launch/java11/ZephyrLaunchHelpers.java
@@ -1,15 +1,21 @@
 /*
- * Copyright (c) 2019 Intel Corporation
+ * Copyright (c) 2019-2020 Intel Corporation
  *
  * SPDX-License-Identifier: EPL-2.0
  */
 
 package org.zephyrproject.ide.eclipse.core.internal.launch.java11;
 
+import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
+
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunch;
 import org.zephyrproject.ide.eclipse.core.build.ZephyrApplicationBuildConfiguration;
@@ -19,6 +25,27 @@ import org.zephyrproject.ide.eclipse.core.launch.IZephyrLaunchHelper;
 public final class ZephyrLaunchHelpers implements IZephyrLaunchHelper {
 
 	public ZephyrLaunchHelpers() {
+	}
+
+	private static String findCommand(String command) {
+		if (Platform.getOS().equals(Platform.OS_WIN32)) {
+			if (!command.toString().endsWith(".exe") //$NON-NLS-1$
+					&& !command.toString().endsWith(".bat")) { //$NON-NLS-1$
+				command = command.trim() + ".exe"; //$NON-NLS-1$
+			}
+		}
+
+		/* Look for it in the path environment var */
+		String path = System.getenv("PATH"); //$NON-NLS-1$
+		for (String entry : path.split(File.pathSeparator)) {
+			Path entryPath = Paths.get(entry);
+			Path cmdPath = entryPath.resolve(command);
+			if (Files.isExecutable(cmdPath)) {
+				return cmdPath.toString();
+			}
+		}
+
+		return null;
 	}
 
 	public Process doMakefile(IProject project,
@@ -63,6 +90,14 @@ public final class ZephyrLaunchHelpers implements IZephyrLaunchHelper {
 			ZephyrApplicationBuildConfiguration appBuildCfg, ILaunch launch,
 			String action, String args) throws CoreException, IOException {
 		String westPath = ZephyrHelpers.getWestPath(project);
+
+		/*
+		 * Path to West may not have been cached by CMake.
+		 * So this try to find West here.
+		 */
+		if ((westPath == null) || (westPath.trim().isEmpty())) {
+			westPath = findCommand("west"); //$NON-NLS-1$
+		}
 
 		if ((westPath == null) || (westPath.trim().isEmpty())) {
 			throw new CoreException(ZephyrHelpers.errorStatus(

--- a/plugins/org.zephyrproject.ide.eclipse.core.linux/src/org/zephyrproject/ide/eclipse/core/internal/launch/linux/ZephyrLaunchHelpers.java
+++ b/plugins/org.zephyrproject.ide.eclipse.core.linux/src/org/zephyrproject/ide/eclipse/core/internal/launch/linux/ZephyrLaunchHelpers.java
@@ -98,7 +98,16 @@ public final class ZephyrLaunchHelpers implements IZephyrLaunchHelper {
 		}
 
 		ArrayList<String> cmds = new ArrayList<String>();
-		cmds.add(westPath);
+
+		if (westPath.indexOf(';') == -1) {
+			cmds.add(westPath);
+		} else {
+			String[] westPathBits = westPath.split(";");
+			for (String s : westPathBits) {
+				cmds.add(s);
+			}
+		}
+
 		cmds.add(action);
 		if (args != null) {
 			cmds.add(args);

--- a/plugins/org.zephyrproject.ide.eclipse.core.macosx/src/org/zephyrproject/ide/eclipse/core/internal/launch/macosx/ZephyrLaunchHelpers.java
+++ b/plugins/org.zephyrproject.ide.eclipse.core.macosx/src/org/zephyrproject/ide/eclipse/core/internal/launch/macosx/ZephyrLaunchHelpers.java
@@ -98,7 +98,16 @@ public final class ZephyrLaunchHelpers implements IZephyrLaunchHelper {
 		}
 
 		ArrayList<String> cmds = new ArrayList<String>();
-		cmds.add(westPath);
+
+		if (westPath.indexOf(';') == -1) {
+			cmds.add(westPath);
+		} else {
+			String[] westPathBits = westPath.split(";");
+			for (String s : westPathBits) {
+				cmds.add(s);
+			}
+		}
+
 		cmds.add(action);
 		if (args != null) {
 			cmds.add(args);

--- a/plugins/org.zephyrproject.ide.eclipse.core.macosx/src/org/zephyrproject/ide/eclipse/core/internal/launch/macosx/ZephyrLaunchHelpers.java
+++ b/plugins/org.zephyrproject.ide.eclipse.core.macosx/src/org/zephyrproject/ide/eclipse/core/internal/launch/macosx/ZephyrLaunchHelpers.java
@@ -1,12 +1,16 @@
 /*
- * Copyright (c) 2019 Intel Corporation
+ * Copyright (c) 2019-2020 Intel Corporation
  *
  * SPDX-License-Identifier: EPL-2.0
  */
 
 package org.zephyrproject.ide.eclipse.core.internal.launch.macosx;
 
+import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 
 import org.eclipse.core.resources.IProject;
@@ -20,6 +24,20 @@ import org.zephyrproject.ide.eclipse.core.launch.IZephyrLaunchHelper;
 public final class ZephyrLaunchHelpers implements IZephyrLaunchHelper {
 
 	public ZephyrLaunchHelpers() {
+	}
+
+	private static String findCommand(String command) {
+		/* Look for it in the path environment var */
+		String path = System.getenv("PATH"); //$NON-NLS-1$
+		for (String entry : path.split(File.pathSeparator)) {
+			Path entryPath = Paths.get(entry);
+			Path cmdPath = entryPath.resolve(command);
+			if (Files.isExecutable(cmdPath)) {
+				return cmdPath.toString();
+			}
+		}
+
+		return null;
 	}
 
 	public Process doMakefile(IProject project,
@@ -64,6 +82,14 @@ public final class ZephyrLaunchHelpers implements IZephyrLaunchHelper {
 			ZephyrApplicationBuildConfiguration appBuildCfg, ILaunch launch,
 			String action, String args) throws CoreException, IOException {
 		String westPath = ZephyrHelpers.getWestPath(project);
+
+		/*
+		 * Path to West may not have been cached by CMake.
+		 * So this try to find West here.
+		 */
+		if ((westPath == null) || (westPath.trim().isEmpty())) {
+			westPath = findCommand("west"); //$NON-NLS-1$
+		}
 
 		if ((westPath == null) || (westPath.trim().isEmpty())) {
 			throw new CoreException(ZephyrHelpers.errorStatus(

--- a/plugins/org.zephyrproject.ide.eclipse.core/src/org/zephyrproject/ide/eclipse/core/build/ZephyrApplicationBuildConfiguration.java
+++ b/plugins/org.zephyrproject.ide.eclipse.core/src/org/zephyrproject/ide/eclipse/core/build/ZephyrApplicationBuildConfiguration.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015, 2016 QNX Software Systems and others.
- * Copyright (c) 2019 Intel Corporation
+ * Copyright (c) 2019-2020 Intel Corporation
  *
  * SPDX-License-Identifier: EPL-2.0
  */
@@ -635,7 +635,10 @@ public class ZephyrApplicationBuildConfiguration extends CBuildConfiguration {
 						cache.getMakeProgram());
 				pStore.putValue(CMakeCache.CMAKE_GDB, cache.getGdb());
 
-				pStore.putValue(CMakeCache.WEST, cache.getWest());
+				String west = cache.getWest();
+				if (west != null) {
+					pStore.putValue(CMakeCache.WEST, cache.getWest());
+				}
 
 				String val = cache.getDebugRunner();
 				if ((val != null) && !val.isEmpty()) {

--- a/plugins/org.zephyrproject.ide.eclipse.core/src/org/zephyrproject/ide/eclipse/core/internal/build/CMakeCache.java
+++ b/plugins/org.zephyrproject.ide.eclipse.core/src/org/zephyrproject/ide/eclipse/core/internal/build/CMakeCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Intel Corporation
+ * Copyright (c) 2019-2020 Intel Corporation
  *
  * SPDX-License-Identifier: EPL-2.0
  */
@@ -83,7 +83,22 @@ public class CMakeCache {
 	 *         not of type FILEPATH
 	 */
 	public String getFilePath(String name) {
-		return getTypedValue("FILEPATH=", name); //$NON-NLS-1$
+		String val = getTypedValue("FILEPATH=", name); //$NON-NLS-1$
+
+		if ((val != null) && (val.indexOf("-NOTFOUND") != -1)) {
+			return null;
+		}
+
+		return val;
+	}
+
+	/**
+	 * @param name Name of cached variable with type INTERNAL
+	 * @return The INTERNAL value or {@code null} if variable does not exist or
+	 *         not of type INTERNAL
+	 */
+	public String getInternal(String name) {
+		return getTypedValue("INTERNAL=", name); //$NON-NLS-1$
 	}
 
 	/**
@@ -118,7 +133,15 @@ public class CMakeCache {
 	 * @return Path to West as discovered by CMake
 	 */
 	public String getWest() {
-		return getFilePath(WEST);
+		/* WEST can appear as FILEPATH or INTERNAL. */
+
+		String val = getFilePath(WEST);
+
+		if (val == null) {
+			val = getInternal(WEST);
+		}
+
+		return val;
 	}
 
 	/**

--- a/plugins/org.zephyrproject.ide.eclipse.core/src/org/zephyrproject/ide/eclipse/core/launch/ZephyrApplicationEmulatorDebugLaunchConfigDelegate.java
+++ b/plugins/org.zephyrproject.ide.eclipse.core/src/org/zephyrproject/ide/eclipse/core/launch/ZephyrApplicationEmulatorDebugLaunchConfigDelegate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Intel Corporation
+ * Copyright (c) 2019-2020 Intel Corporation
  *
  * SPDX-License-Identifier: EPL-2.0
  */
@@ -88,12 +88,12 @@ public class ZephyrApplicationEmulatorDebugLaunchConfigDelegate
 			String args = configuration.getAttribute(
 					ZephyrLaunchConstants.ATTR_DBGSERVER_CMD_WEST_ARGS,
 					ZephyrStrings.EMPTY_STRING);
-			if (args.trim().isEmpty()) {
-				args = null;
-			}
+
+			args = "-t debugserver " + args; //$NON-NLS-1$
+			args = args.trim();
 
 			ZephyrHelpers.Launch.runWest(project, appBuildCfg, launch,
-					CMD_DEBUGSERVER, args);
+					"build", args); //$NON-NLS-1$
 		} else if (commandSelection
 				.equals(ZephyrLaunchConstants.DBGSERVER_CMD_SEL_NONE)) {
 			/* Instructed not to launch debugserver */

--- a/plugins/org.zephyrproject.ide.eclipse.core/src/org/zephyrproject/ide/eclipse/core/launch/ZephyrApplicationEmulatorRunLaunchConfigDelegate.java
+++ b/plugins/org.zephyrproject.ide.eclipse.core/src/org/zephyrproject/ide/eclipse/core/launch/ZephyrApplicationEmulatorRunLaunchConfigDelegate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Intel Corporation
+ * Copyright (c) 2019-2020 Intel Corporation
  *
  * SPDX-License-Identifier: EPL-2.0
  */
@@ -81,11 +81,11 @@ public class ZephyrApplicationEmulatorRunLaunchConfigDelegate
 			String args = configuration.getAttribute(
 					ZephyrLaunchConstants.ATTR_RUN_CMD_WEST_ARGS,
 					ZephyrStrings.EMPTY_STRING);
-			if (args.trim().isEmpty()) {
-				args = null;
-			}
 
-			runWest(project, appBuildCfg, launch, CMD_RUN, args);
+			args = "-t run " + args; //$NON-NLS-1$
+			args = args.trim();
+
+			runWest(project, appBuildCfg, launch, "build", args); //$NON-NLS-1$
 		} else {
 			throw new CoreException(ZephyrHelpers.errorStatus(
 					"Project is not correctly configured.", //$NON-NLS-1$


### PR DESCRIPTION
* Find West on our own if path does not exist in CMakeCache.
  * The WEST variable in CMakeCache is no longer there due to changes in West and Zephyr cmake files.
* Fix emulator launch targets as West can't do "run" or "debugserver" commands on emulator targets. So do a "build" command with appropriate build targets.