### PR TITLE
Update JTAG devices for CDT 10

### DIFF
--- a/plugins/org.zephyrproject.ide.eclipse.core/plugin.xml
+++ b/plugins/org.zephyrproject.ide.eclipse.core/plugin.xml
@@ -176,26 +176,31 @@
          point="org.eclipse.cdt.debug.gdbjtag.core.JTagDevice">
       <device
             class="org.zephyrproject.ide.eclipse.core.debug.jtagdevice.QEMUDevice"
+            default_connection="localhost:1234"
             id="org.zephyrproject.ide.eclipse.core.debug.jtagdevice.qemuDevice"
             name="QEMU">
       </device>
       <device
             class="org.zephyrproject.ide.eclipse.core.debug.jtagdevice.ARCnSimDevice"
+            default_connection="localhost:3333"
             id="org.zephyrproject.ide.eclipse.core.debug.jtagdevice.arcnSimDevice"
             name="ARC nSIM">
       </device>
       <device
             class="org.zephyrproject.ide.eclipse.core.debug.jtagdevice.XtOCDDevice"
+            default_connection="localhost:20000"
             id="org.zephyrproject.ide.eclipse.core.debug.jtagdevice.xtOCDDevice"
             name="xt-ocd">
       </device>
       <device
             class="org.zephyrproject.ide.eclipse.core.debug.jtagdevice.Nios2Device"
+            default_connection="localhost:3333"
             id="org.zephyrproject.ide.eclipse.core.debug.jtagdevice.nios2Device"
             name="Nios II GDB Server">
       </device>
       <device
             class="org.zephyrproject.ide.eclipse.core.debug.jtagdevice.OpenIPCDevice"
+            default_connection="localhost:8086"
             id="org.zephyrproject.ide.eclipse.core.debug.jtagdevice.openIPCDevice"
             name="OpenIPC">
       </device>

--- a/plugins/org.zephyrproject.ide.eclipse.core/src/org/zephyrproject/ide/eclipse/core/debug/jtagdevice/ARCnSimDevice.java
+++ b/plugins/org.zephyrproject.ide.eclipse.core/src/org/zephyrproject/ide/eclipse/core/debug/jtagdevice/ARCnSimDevice.java
@@ -13,9 +13,9 @@ package org.zephyrproject.ide.eclipse.core.debug.jtagdevice;
 
 import java.util.Collection;
 
-import org.eclipse.cdt.debug.gdbjtag.core.jtagdevice.DefaultGDBJtagDeviceImpl;
+import org.eclipse.cdt.debug.gdbjtag.core.jtagdevice.DefaultGDBJtagConnectionImpl;
 
-public class ARCnSimDevice extends DefaultGDBJtagDeviceImpl {
+public class ARCnSimDevice extends DefaultGDBJtagConnectionImpl {
 
 	@Override
 	public void doDelay(int delay, Collection<String> commands) {
@@ -27,16 +27,6 @@ public class ARCnSimDevice extends DefaultGDBJtagDeviceImpl {
 
 	@Override
 	public void doReset(Collection<String> commands) {
-	}
-
-	@Override
-	public String getDefaultIpAddress() {
-		return "localhost"; //$NON-NLS-1$
-	}
-
-	@Override
-	public String getDefaultPortNumber() {
-		return "3333"; //$NON-NLS-1$
 	}
 
 }

--- a/plugins/org.zephyrproject.ide.eclipse.core/src/org/zephyrproject/ide/eclipse/core/debug/jtagdevice/Nios2Device.java
+++ b/plugins/org.zephyrproject.ide.eclipse.core/src/org/zephyrproject/ide/eclipse/core/debug/jtagdevice/Nios2Device.java
@@ -13,9 +13,9 @@ package org.zephyrproject.ide.eclipse.core.debug.jtagdevice;
 
 import java.util.Collection;
 
-import org.eclipse.cdt.debug.gdbjtag.core.jtagdevice.DefaultGDBJtagDeviceImpl;
+import org.eclipse.cdt.debug.gdbjtag.core.jtagdevice.DefaultGDBJtagConnectionImpl;
 
-public class Nios2Device extends DefaultGDBJtagDeviceImpl {
+public class Nios2Device extends DefaultGDBJtagConnectionImpl {
 
 	@Override
 	public void doDelay(int delay, Collection<String> commands) {
@@ -27,16 +27,6 @@ public class Nios2Device extends DefaultGDBJtagDeviceImpl {
 
 	@Override
 	public void doReset(Collection<String> commands) {
-	}
-
-	@Override
-	public String getDefaultIpAddress() {
-		return "localhost"; //$NON-NLS-1$
-	}
-
-	@Override
-	public String getDefaultPortNumber() {
-		return "3333"; //$NON-NLS-1$
 	}
 
 }

--- a/plugins/org.zephyrproject.ide.eclipse.core/src/org/zephyrproject/ide/eclipse/core/debug/jtagdevice/OpenIPCDevice.java
+++ b/plugins/org.zephyrproject.ide.eclipse.core/src/org/zephyrproject/ide/eclipse/core/debug/jtagdevice/OpenIPCDevice.java
@@ -13,14 +13,9 @@ package org.zephyrproject.ide.eclipse.core.debug.jtagdevice;
 
 import java.util.Collection;
 
-import org.eclipse.cdt.debug.gdbjtag.core.jtagdevice.DefaultGDBJtagDeviceImpl;
+import org.eclipse.cdt.debug.gdbjtag.core.jtagdevice.DefaultGDBJtagConnectionImpl;
 
-public class OpenIPCDevice extends DefaultGDBJtagDeviceImpl {
-
-	@Override
-	public String getDefaultPortNumber() {
-		return "8086"; //$NON-NLS-1$
-	}
+public class OpenIPCDevice extends DefaultGDBJtagConnectionImpl {
 
 	@Override
 	public void doDelay(int delay, Collection<String> commands) {

--- a/plugins/org.zephyrproject.ide.eclipse.core/src/org/zephyrproject/ide/eclipse/core/debug/jtagdevice/QEMUDevice.java
+++ b/plugins/org.zephyrproject.ide.eclipse.core/src/org/zephyrproject/ide/eclipse/core/debug/jtagdevice/QEMUDevice.java
@@ -13,9 +13,9 @@ package org.zephyrproject.ide.eclipse.core.debug.jtagdevice;
 
 import java.util.Collection;
 
-import org.eclipse.cdt.debug.gdbjtag.core.jtagdevice.DefaultGDBJtagDeviceImpl;
+import org.eclipse.cdt.debug.gdbjtag.core.jtagdevice.DefaultGDBJtagConnectionImpl;
 
-public class QEMUDevice extends DefaultGDBJtagDeviceImpl {
+public class QEMUDevice extends DefaultGDBJtagConnectionImpl {
 
 	@Override
 	public void doDelay(int delay, Collection<String> commands) {
@@ -27,16 +27,6 @@ public class QEMUDevice extends DefaultGDBJtagDeviceImpl {
 
 	@Override
 	public void doReset(Collection<String> commands) {
-	}
-
-	@Override
-	public String getDefaultIpAddress() {
-		return "localhost"; //$NON-NLS-1$
-	}
-
-	@Override
-	public String getDefaultPortNumber() {
-		return "1234"; //$NON-NLS-1$
 	}
 
 }

--- a/plugins/org.zephyrproject.ide.eclipse.core/src/org/zephyrproject/ide/eclipse/core/debug/jtagdevice/XtOCDDevice.java
+++ b/plugins/org.zephyrproject.ide.eclipse.core/src/org/zephyrproject/ide/eclipse/core/debug/jtagdevice/XtOCDDevice.java
@@ -13,9 +13,9 @@ package org.zephyrproject.ide.eclipse.core.debug.jtagdevice;
 
 import java.util.Collection;
 
-import org.eclipse.cdt.debug.gdbjtag.core.jtagdevice.DefaultGDBJtagDeviceImpl;
+import org.eclipse.cdt.debug.gdbjtag.core.jtagdevice.DefaultGDBJtagConnectionImpl;
 
-public class XtOCDDevice extends DefaultGDBJtagDeviceImpl {
+public class XtOCDDevice extends DefaultGDBJtagConnectionImpl {
 
 	@Override
 	public void doDelay(int delay, Collection<String> commands) {
@@ -27,16 +27,6 @@ public class XtOCDDevice extends DefaultGDBJtagDeviceImpl {
 
 	@Override
 	public void doReset(Collection<String> commands) {
-	}
-
-	@Override
-	public String getDefaultIpAddress() {
-		return "localhost"; //$NON-NLS-1$
-	}
-
-	@Override
-	public String getDefaultPortNumber() {
-		return "20000"; //$NON-NLS-1$
 	}
 
 }

--- a/plugins/org.zephyrproject.ide.eclipse.ui/src/org/zephyrproject/ide/eclipse/ui/internal/launch/tabs/CommonDebugLaunchDebuggerTab.java
+++ b/plugins/org.zephyrproject.ide.eclipse.ui/src/org/zephyrproject/ide/eclipse/ui/internal/launch/tabs/CommonDebugLaunchDebuggerTab.java
@@ -23,9 +23,8 @@ public abstract class CommonDebugLaunchDebuggerTab
 		extends GDBJtagDSFDebuggerTab {
 
 	protected String defaultJtagDevice = JTagDeviceDesc.GENERIC_TCPIP_DEVICE;
-	protected String defaultHost = JTagDeviceDesc.IP_ADDR_LOCALHOST;
-	protected Integer defaultPort = 10000;
-	protected String defaultConnection = null;
+	protected String defaultConnection =
+			String.format("%s:%d", JTagDeviceDesc.IP_ADDR_LOCALHOST, 10000);
 
 	protected JTagDeviceDesc[] jtagDevices = new JTagDeviceDesc[] {
 
@@ -33,10 +32,10 @@ public abstract class CommonDebugLaunchDebuggerTab
 
 		new JTagDeviceDesc("arc-nsim", //$NON-NLS-1$
 				"org.zephyrproject.ide.eclipse.core.debug.jtagdevice.arcnSimDevice", //$NON-NLS-1$
-				JTagDeviceDesc.IP_ADDR_LOCALHOST, 3333),
+				String.format("%s:%d", JTagDeviceDesc.IP_ADDR_LOCALHOST, 3333)),
 		new JTagDeviceDesc("qemu", //$NON-NLS-1$
 				"org.zephyrproject.ide.eclipse.core.debug.jtagdevice.qemuDevice", //$NON-NLS-1$
-				JTagDeviceDesc.IP_ADDR_LOCALHOST, 1234),
+				String.format("%s:%d", JTagDeviceDesc.IP_ADDR_LOCALHOST, 1234)),
 
 		/* Hardware targets */
 
@@ -45,19 +44,20 @@ public abstract class CommonDebugLaunchDebuggerTab
 				"/dev/ttyACM0"), //$NON-NLS-1$
 		new JTagDeviceDesc("intel_s1000", //$NON-NLS-1$
 				"org.zephyrproject.ide.eclipse.core.debug.jtagdevice.xtOCDDevice", //$NON-NLS-1$
-				JTagDeviceDesc.IP_ADDR_LOCALHOST, 20000),
+				String.format("%s:%d", JTagDeviceDesc.IP_ADDR_LOCALHOST,
+						20000)),
 		new JTagDeviceDesc("JLink", //$NON-NLS-1$
 				"org.eclipse.cdt.debug.gdbjtag.core.jtagdevice.SeggerJLink", //$NON-NLS-1$
-				JTagDeviceDesc.IP_ADDR_LOCALHOST, 2331),
+				String.format("%s:%d", JTagDeviceDesc.IP_ADDR_LOCALHOST, 2331)),
 		new JTagDeviceDesc("nios2", //$NON-NLS-1$
 				"org.zephyrproject.ide.eclipse.core.debug.jtagdevice.nios2Device", //$NON-NLS-1$
-				JTagDeviceDesc.IP_ADDR_LOCALHOST, 3333),
+				String.format("%s:%d", JTagDeviceDesc.IP_ADDR_LOCALHOST, 3333)),
 		new JTagDeviceDesc("openocd", //$NON-NLS-1$
 				"org.eclipse.cdt.debug.gdbjtag.core.jtagdevice.OpenOCDSocket", //$NON-NLS-1$
-				JTagDeviceDesc.IP_ADDR_LOCALHOST, 3333),
+				String.format("%s:%d", JTagDeviceDesc.IP_ADDR_LOCALHOST, 3333)),
 		new JTagDeviceDesc("openipc", //$NON-NLS-1$
 				"org.zephyrproject.ide.eclipse.core.debug.jtagdevice.openIPCDevice", //$NON-NLS-1$
-				JTagDeviceDesc.IP_ADDR_LOCALHOST, 8086),
+				String.format("%s:%d", JTagDeviceDesc.IP_ADDR_LOCALHOST, 8086)),
 	};
 
 	@Override
@@ -69,8 +69,6 @@ public abstract class CommonDebugLaunchDebuggerTab
 
 		String device = defaultJtagDevice;
 		String connection = defaultConnection;
-		String ipAddr = defaultHost;
-		Integer ipPort = defaultPort;
 
 		/* Grab GDB path and runner from CMake */
 		try {
@@ -103,8 +101,7 @@ public abstract class CommonDebugLaunchDebuggerTab
 								if (jtag.connection != null) {
 									connection = jtag.connection;
 								} else {
-									ipAddr = jtag.host;
-									ipPort = jtag.port;
+									connection = defaultConnection;
 								}
 
 								break;
@@ -119,16 +116,18 @@ public abstract class CommonDebugLaunchDebuggerTab
 
 		configuration.setAttribute(IGDBJtagConstants.ATTR_JTAG_DEVICE_ID,
 				device);
-		if (connection != null) {
-			configuration.setAttribute(IGDBJtagConstants.ATTR_CONNECTION,
-					connection);
-		} else {
-			configuration.setAttribute(IGDBJtagConstants.ATTR_IP_ADDRESS,
-					ipAddr);
 
-			configuration.setAttribute(IGDBJtagConstants.ATTR_PORT_NUMBER,
-					ipPort);
+		String connText;
+		if (connection != null) {
+			connText = connection;
+		} else {
+			connText = defaultConnection;
 		}
+
+		/* The ATTR_CONNECTION attribute needs "gdb:" prefix */
+		connText = String.format("gdb:%s", connText);
+
+		configuration.setAttribute(IGDBJtagConstants.ATTR_CONNECTION, connText);
 	}
 
 }

--- a/plugins/org.zephyrproject.ide.eclipse.ui/src/org/zephyrproject/ide/eclipse/ui/launch/tabs/EmulatorDebugLaunchDebuggerTab.java
+++ b/plugins/org.zephyrproject.ide.eclipse.ui/src/org/zephyrproject/ide/eclipse/ui/launch/tabs/EmulatorDebugLaunchDebuggerTab.java
@@ -21,8 +21,8 @@ public class EmulatorDebugLaunchDebuggerTab
 		 */
 		super.defaultJtagDevice =
 				"org.zephyrproject.ide.eclipse.core.debug.jtagdevice.qemuDevice"; //$NON-NLS-1$
-		super.defaultHost = JTagDeviceDesc.IP_ADDR_LOCALHOST;
-		super.defaultPort = 1234;
+		super.defaultConnection =
+				String.format("%s:%d", JTagDeviceDesc.IP_ADDR_LOCALHOST, 1234);
 	}
 
 }

--- a/plugins/org.zephyrproject.ide.eclipse.ui/src/org/zephyrproject/ide/eclipse/ui/launch/tabs/HardwareDebugLaunchDebuggerTab.java
+++ b/plugins/org.zephyrproject.ide.eclipse.ui/src/org/zephyrproject/ide/eclipse/ui/launch/tabs/HardwareDebugLaunchDebuggerTab.java
@@ -18,8 +18,8 @@ public class HardwareDebugLaunchDebuggerTab
 		/* Most boards use OpenOCD or pyOCD, so set it as default */
 		super.defaultJtagDevice =
 				"org.eclipse.cdt.debug.gdbjtag.core.jtagdevice.OpenOCDSocket"; //$NON-NLS-1$
-		super.defaultHost = JTagDeviceDesc.IP_ADDR_LOCALHOST;
-		super.defaultPort = 3333;
+		super.defaultConnection =
+				String.format("%s:%d", JTagDeviceDesc.IP_ADDR_LOCALHOST, 3333);
 	}
 
 }


### PR DESCRIPTION
CDT 10 no longer uses DefaultGDBJtagDeviceImpl but instead
DefaultGDBJtagConnectionImpl. The new class uses URI for
connection instead of separate host/port fields. So update
the debugger tab and all JTAG device classes.

Fixes #35

Signed-off-by: Daniel Leung <daniel.leung@intel.com>