### PR TITLE
build: fix getting cmake_cxx_compiler from cache

### DIFF
--- a/plugins/org.zephyrproject.ide.eclipse.core/src/org/zephyrproject/ide/eclipse/core/internal/build/CMakeCache.java
+++ b/plugins/org.zephyrproject.ide.eclipse.core/src/org/zephyrproject/ide/eclipse/core/internal/build/CMakeCache.java
@@ -112,7 +112,14 @@ public class CMakeCache {
 	 * @return Path to C++ compiler as discovered by CMake
 	 */
 	public String getCXXCompiler() {
-		return getFilePath(CMAKE_CXX_COMPILER);
+		/* CMAKE_CXX_COMPILER can appear as FILEPATH or STRING */
+		String cxx_compiler = getFilePath(CMAKE_CXX_COMPILER);
+
+		if (cxx_compiler == null) {
+			cxx_compiler = getString(CMAKE_CXX_COMPILER);
+		}
+
+		return cxx_compiler;
 	}
 
 	/**


### PR DESCRIPTION
CMakeCache.txt is showing CMAKE_CXX_COMPILER as a STRING instead of
FILEPATH. When plugin retrieves cache information, it is failing to
recover CMAKE_CXX_COMPILER, and triggering and execution during build.
Searching for STRING if FILEPATH is not found solves the issue.

Signed-off-by: Marta Navarro <marta.navarro@intel.com>