### PR TITLE
build: fix getting cmake_c_compiler from cache

### DIFF
--- a/plugins/org.zephyrproject.ide.eclipse.core/src/org/zephyrproject/ide/eclipse/core/internal/build/CMakeCache.java
+++ b/plugins/org.zephyrproject.ide.eclipse.core/src/org/zephyrproject/ide/eclipse/core/internal/build/CMakeCache.java
@@ -105,7 +105,14 @@ public class CMakeCache {
 	 * @return Path to C compiler as discovered by CMake
 	 */
 	public String getCCompiler() {
-		return getFilePath(CMAKE_C_COMPILER);
+		/* CMAKE_C_COMPILER can appear as FILEPATH or STRING */
+		String c_compiler = getFilePath(CMAKE_C_COMPILER);
+
+		if (c_compiler == null) {
+			c_compiler = getString(CMAKE_C_COMPILER);
+		}
+
+		return c_compiler;
 	}
 
 	/**


### PR DESCRIPTION
CMakeCache.txt is showing CMAKE_C_COMPILER as a STRING instead of
FILEPATH the first time that we build from plugin. When plugin retrieves
cache information, it is failing to recover CMAKE_C_COMPILER, and
triggering an exception during build. Searching for STRING if FILEPATH
is not found solves the issue.

Signed-off-by: Marta Navarro <marta.navarro@intel.com>